### PR TITLE
Fixing unsupported MySQL version

### DIFF
--- a/cfn-nested-repo/database-stack.yml
+++ b/cfn-nested-repo/database-stack.yml
@@ -50,7 +50,7 @@ Resources:
       DBSubnetGroupName:
         Ref: DBSubnetGroup
       Engine: mysql
-      EngineVersion: 5.7.11
+      EngineVersion: 5.7
       MasterUsername:
         Ref: DBUsername
       MasterUserPassword:


### PR DESCRIPTION
Fixing an issue caused by unsupported MySQL version 5.7.11. The updated code will default to the latest supported version which is currently MySQL 5.7.21. Link to supported MySQL versions below.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt